### PR TITLE
Switch style to purplelight

### DIFF
--- a/build-html/map_weicdata.html
+++ b/build-html/map_weicdata.html
@@ -299,7 +299,7 @@
             
             const map = new mapboxgl.Map({
                 container: 'map',
-                style: params.styles.purpledark,
+                style: params.styles.purplelight,
                 projection: params.projections.globe,
                 center: params.center,
                 hash: params.hash,


### PR DESCRIPTION
Switch style from purpledark to purplelight after publishing style changes on Mapbox (hiding extruded buildings layer in style)