### PR TITLE
Remove .setPath()

### DIFF
--- a/build-html/map_weicdata.html
+++ b/build-html/map_weicdata.html
@@ -1614,9 +1614,9 @@
                     this.scene.add(directionalLight2);
 
                     // use the three.js GLTF loader to add the 3D model to the three.js scene
-                    var loader = new THREE.GLTFLoader().setPath('https://raw.githubusercontent.com/de-data-lab/map3d-ar/main/assets/custom3d/');
+                    var loader = new THREE.GLTFLoader();
                     loader.load(
-                        '34M_17.gltf',
+                        'https://raw.githubusercontent.com/de-data-lab/map3d-ar/main/assets/custom3d/34M_17.gltf',
                     function (gltf) {
                             console.log(gltf);
                             this.scene.add(gltf.scene);


### PR DESCRIPTION
Remove .setPath in favor of the full path in the loader.load(), to avoid bug in which the loader searches for a file ending in .bin instead of the desired .gltf