### PR TITLE
Fix insecure D3 path; Fix GLTFLoader path

### DIFF
--- a/build-html/map_weicdata.html
+++ b/build-html/map_weicdata.html
@@ -30,7 +30,7 @@
         <script src="https://unpkg.com/three@0.126.0/examples/js/loaders/GLTFLoader.js"></script>
 
         <!-- D3.js  -->
-        <script src="http://d3js.org/d3.v3.min.js"></script>
+        <script src="https://d3js.org/d3.v3.min.js"></script>
         <script src="https://d3js.org/d3-collection.v1.min.js"></script>
         <script src="https://d3js.org/d3-dispatch.v1.min.js"></script>
         <script src="https://d3js.org/d3-dsv.v1.min.js"></script>
@@ -1616,7 +1616,7 @@
                     // use the three.js GLTF loader to add the 3D model to the three.js scene
                     var loader = new THREE.GLTFLoader();
                     loader.load(
-                        'https://raw.githubusercontent.com/de-data-lab/map3d-ar/main/assets/custom3d/ti3d.gltf',
+                        'https://docs.mapbox.com/mapbox-gl-js/assets/34M_17/34M_17.gltf',
                     function (gltf) {
                             console.log(gltf);
                             this.scene.add(gltf.scene);


### PR DESCRIPTION
Fix an insecure "http://" D3.js src; Fix the GLTFLoader path to an object that will not overrun the buffer, pending bug fixes for the buffer problem