### PR TITLE
Fix Parser src path

### DIFF
--- a/build-html/map_weicdata.html
+++ b/build-html/map_weicdata.html
@@ -32,7 +32,7 @@
         <script src="../node_modules/threebox-plugin/dist/threebox.js" type="text/javascript"></script>
 
         <!-- Parser.js -->
-        <script src="../js/parser.js"></script>
+        <script src="./js/parser.js"></script>
 
         <!-- D3.js  -->
         <script src="https://d3js.org/d3.v3.min.js"></script>


### PR DESCRIPTION
Parser.js import may be removed in a future commit, but for now, fix the src path in the HTML head