### PR TITLE
Correct path to Parser.js

### DIFF
--- a/build-html/map_weicdata.html
+++ b/build-html/map_weicdata.html
@@ -32,7 +32,7 @@
         <script src="../node_modules/threebox-plugin/dist/threebox.js" type="text/javascript"></script>
 
         <!-- Parser.js -->
-        <script src="../js/parser.js"></script>
+        <script src="./js/parser.js"></script>
 
         <style type="text/css">
             @font-face {


### PR DESCRIPTION
Edit script tag src path to Parser.js, which had been throwing a 404