### PR TITLE
Comment out 'peak's Threebox layer

### DIFF
--- a/build-html/map_weicdata.html
+++ b/build-html/map_weicdata.html
@@ -2177,6 +2177,11 @@
             */
 
             
+
+            // Just commenting out,
+            // in case the GitHub deployment needs to be demo'ed in a jiffy
+            /*
+             *
             // Add 3D layer
             map.on('style.load', function() {
                 map.addLayer({
@@ -2223,6 +2228,8 @@
                     }
                 })
             })
+            *
+            */
         </script>
     </body>
 </html>


### PR DESCRIPTION
Comment out Threebox layer 'peaks', which creates the 3D heatmap; this is because the 3D heatmap is not perfect / presentable at the moment, and while we need to store its code, I want to keep it hidden in case this project needs to be demo'ed on short notice. The demo should not have half-finished parts in it.