### PR TITLE
Add text-translate to cluster-count

### DIFF
--- a/build-html/map_weicdata.html
+++ b/build-html/map_weicdata.html
@@ -984,10 +984,11 @@
                     layout: {
                         'text-field': ['get', 'point_count'],
                         'text-font': ['DIN Offc Pro Medium', 'Arial Unicode MS Bold'],
-                        'text-size': 12
+                        'text-size': 12,
                     },
                     paint: {
-                        'text-opacity': 0
+                        'text-opacity': 1,
+                        'text-translate': [0, 12]
                     }
                 });
                 //Layer for unclustered points


### PR DESCRIPTION
Set text-opacity in cluster-count from 0 to 1; add text-translate of [0, 12] so that cluster-count labels are not blocked by the elevation 3D objects