### PR TITLE
Update crashes source data url

### DIFF
--- a/build-html/map_traffic.html
+++ b/build-html/map_traffic.html
@@ -780,7 +780,7 @@
                 });
                 map.addSource('crashes', {
                     type: 'geojson',
-                    data: 'https://data.delaware.gov/resource/827n-m6xc.geojson',
+                    data: 'https://data.delaware.gov/resource/827n-m6xc.geojson?$where=crash_datetime%20%3E%20%272021-12-31T11:59:00.000Z%27&$limit=75000',
                     cluster: true,
                     clusterMaxZoom: 12,
                     clusterRadius: 80


### PR DESCRIPTION
Update the data url for the 'crashes' source to implement SoQL, retrieving only the crashes from 2022, with a row limit of 75000